### PR TITLE
fix: add alias false to node apis

### DIFF
--- a/codux.config.json
+++ b/codux.config.json
@@ -32,7 +32,20 @@
       "@styles": "./src/styles",
       "@styles/*": "./src/styles/*",
       "/*": "./*",
-      "~/*": "./src/*"
+      "~/*": "./src/*",
+      "node:fs": false,
+      "node:fs/promises": false,
+      "node:path": false,
+      "node:crypto": false,
+      "crypto": false,
+      "node:stream": false,
+      "stream": false,
+      "node:os": false,
+      "node:util": false,
+      "node:events": false,
+      "node:url": false,
+      "node:buffer": false,
+      "node:assert": false
     }
   },
   "svgLoader": "both"


### PR DESCRIPTION
Remix has some node apis that you should use in order to call some server side functions, but it is written the same place where a component file is.
Our code doesn't know that they exists and just throws an error.
We added to Codux and Codux-Core solutions to this problem, but we need to change also the templates side:
We need to add these aliases so preview would not show error but will call our own implementations of remix node apis.
This kind of PR will show again in other remix-templates also.