### PR TITLE
refactor: replace css reset

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -30,7 +30,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
 export default function App() {
     return (
-        <div>
+        <div id="root">
             <Outlet />
         </div>
     );

--- a/app/routes/_index/_index.module.scss
+++ b/app/routes/_index/_index.module.scss
@@ -10,6 +10,10 @@
     border-radius: 30px;
 }
 
+.title {
+    font: $large-font;
+}
+
 .paragraph {
     font-size: 12px;
     margin-top: 80px;

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -13,7 +13,7 @@ export const loader = ({ request }: LoaderFunctionArgs) => {
 export default function HomePage() {
     return (
         <div className={styles.root}>
-            <h2>Welcome to your App Homepage 🎉</h2>
+            <h2 className={styles.title}>Welcome to your App Homepage 🎉</h2>
             <span>
                 Double click to edit App component
                 <br />

--- a/src/components/error-component/error-component.module.scss
+++ b/src/components/error-component/error-component.module.scss
@@ -1,9 +1,15 @@
+@import '@styles/theme.module.scss';
+
 .root {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     gap: 10px;
+}
+
+.heading1 {
+    font: $title-font;
 }
 
 .link {

--- a/src/components/error-component/error-component.tsx
+++ b/src/components/error-component/error-component.tsx
@@ -12,7 +12,7 @@ export interface ErrorProps {
 export const ErrorComponent = ({ title, message }: ErrorProps) => {
     return (
         <div className={styles.root}>
-            <h1>{title ?? unknownErrorTitle}</h1>
+            <h1 className={styles.heading1}>{title ?? unknownErrorTitle}</h1>
             {message && <div>{message}</div>}
             <Link to={ROUTES.home.to()} className={styles.link}>
                 Navigate to Home Page

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -19,3 +19,8 @@ body {
     min-width: 320px;
     min-height: 100vh;
 }
+
+#root {
+    /* create a stacking context for the app */
+    isolation: isolate;
+}

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -1,119 +1,66 @@
-/***
-    The new CSS reset - version 1.11.2 (last updated 15.11.2023)
-    GitHub page: https://github.com/elad2412/the-new-css-reset
-***/
-
-/*
-    Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
-    - The "symbol *" part is to solve Firefox SVG sprite bug
-    - The "html" element is excluded, otherwise a bug in Chrome breaks the CSS hyphens property (https://github.com/elad2412/the-new-css-reset/issues/36)
+/* Josh Comeau CSS Reset 
+ * Source: https://www.joshwcomeau.com/css/custom-css-reset/
+ * Description: A modern CSS reset to improve consistency and control over default styles.
  */
-*:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
-  all: unset;
-  display: revert;
-}
 
-/* Preferred box-sizing value */
+/* 1. Use a more-intuitive box-sizing model */
 *,
 *::before,
 *::after {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
-
-/* Fix mobile Safari increase font-size on landscape mode */
-html {
-  -moz-text-size-adjust: none;
-  -webkit-text-size-adjust: none;
-  text-size-adjust: none;
+/* 2. Remove default margin */
+* {
+    margin: 0;
 }
-
-/* Reapply the pointer cursor for anchor tags */
-a,
-button {
-  cursor: revert;
+body {
+    /* 3. Add accessible line-height */
+    line-height: 1.5;
+    /* 4. Improve text rendering */
+    -webkit-font-smoothing: antialiased;
 }
-
-/* Remove list styles (bullets/numbers) */
-ol,
-ul,
-menu,
-summary {
-  list-style: none;
+/* 5. Improve media defaults */
+img,
+picture,
+video,
+canvas,
+svg {
+    display: block;
+    max-width: 100%;
 }
-
-/* For images to not be able to exceed their container */
-img {
-  max-inline-size: 100%;
-  max-block-size: 100%;
-  /* to avoid the gap created by a space char between inline elements */
-  vertical-align: bottom;
-}
-
-/* removes spacing between cells in tables */
-table {
-  border-collapse: collapse;
-}
-
-/* Safari - solving issue when using user-select:none on the <body> text input doesn't working */
+/* 6. Inherit fonts for form controls */
 input,
-textarea {
-  user-select: auto;
-  -webkit-user-select: auto;
+button,
+textarea,
+select {
+    font: inherit;
+}
+/* 7. Avoid text overflows */
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    overflow-wrap: break-word;
+}
+/* 8. Improve line wrapping */
+p {
+    text-wrap: pretty;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    text-wrap: balance;
 }
 
-/* revert the 'white-space' property for textarea elements on Safari */
-textarea {
-  white-space: revert;
-}
+/* Custom additions to the original Josh Comeau reset by Codux */
 
-/* minimum style to allow to style meter element */
-meter {
-  -webkit-appearance: revert;
-  appearance: revert;
-}
-
-/* preformatted text - use only for this feature */
-:where(pre) {
-  all: revert;
-  box-sizing: border-box;
-}
-
-/* reset default text opacity of input placeholder */
-::placeholder {
-  color: unset;
-}
-
-/* fix the feature of 'hidden' attribute.
-   display:revert; revert to element instead of attribute */
-:where([hidden]) {
-  display: none;
-}
-
-/* revert for bug in Chromium browsers
-   - fix for the content editable attribute will work properly.
-   - webkit-user-select: auto; added for Safari in case of using user-select:none on wrapper element*/
-:where([contenteditable]:not([contenteditable="false"])) {
-  -moz-user-modify: read-write;
-  -webkit-user-modify: read-write;
-  overflow-wrap: break-word;
-  line-break: after-white-space;
-  -webkit-line-break: after-white-space;
-  user-select: auto;
-  -webkit-user-select: auto;
-}
-
-/* apply back the draggable feature - exist only in Chromium and Safari */
-:where([draggable="true"]) {
-  -webkit-user-drag: element;
-}
-
-/* Revert Modal native behavior */
-:where(dialog:modal) {
-  all: revert;
-  box-sizing: border-box;
-}
-
-/* Remove details summary webkit styles */
-::-webkit-details-marker {
-  display: none;
+a {
+    text-decoration: none;
+    color: inherit;
 }


### PR DESCRIPTION
This PR replaces the existing aggressive CSS reset with the [Josh Comeau CSS reset](https://www.joshwcomeau.com/css/custom-css-reset/), aiming to preserve the basic styling of HTML elements when unstyled.

### Changes in this PR:
- Replaced the current CSS reset with a simpler approach to maintain default element styles.
- Set a stacking context for the site wrapper.
- Refactored components to work with the new reset.

### small changes in heading styles
**Home page before**
![image](https://github.com/user-attachments/assets/b2a67dd4-fa3b-40bc-9893-cb680e5c53b1)
**Home page after**
![image](https://github.com/user-attachments/assets/f49ff660-6ffe-4fc7-a916-4449c35af790)

**Error boundary before**
![image](https://github.com/user-attachments/assets/6e59f13e-b68a-4864-87e2-de6335e6fbc3)
**Error boundary after**
![image](https://github.com/user-attachments/assets/5f23662d-1afa-46a0-a056-18264c599fd5)
