### PR TITLE
style: change text-vars font sizes to be `vw` instead of `rem`

### DIFF
--- a/_codux/ui-kit/typography.board.tsx
+++ b/_codux/ui-kit/typography.board.tsx
@@ -12,7 +12,7 @@ export default createBoard({
                         <h1 className="largeFont">Large Font</h1>
                     </Variant>
                     <Kit.Description>
-                        <b>--large-font:</b> DM Sans / 6em / 1.2
+                        <b>--large-font:</b> DM Sans / 8vw / 1.2
                     </Kit.Description>
                 </Kit.Item>
                 <Kit.Item>
@@ -20,7 +20,7 @@ export default createBoard({
                         <h2 className="small-font">Small Font</h2>
                     </Variant>
                     <Kit.Description>
-                        <b>--small-font:</b> DM Sans / 3rem / 1.4
+                        <b>--small-font:</b> DM Sans / 5vw / 1.4
                     </Kit.Description>
                 </Kit.Item>
             </Kit.Section>
@@ -33,7 +33,7 @@ export default createBoard({
                         </div>
                     </Variant>
                     <Kit.Description>
-                        <b>--paragraph-font:</b> DM Sans / 2rem / 1.3
+                        <b>--paragraph-font:</b> DM Sans / 3vw / 1.3
                     </Kit.Description>
                 </Kit.Item>
             </Kit.Section>

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -11,8 +11,8 @@ export default function HomePage() {
         <div className={styles.root}>
             <h2 className={styles.title}>Welcome To App Homepage 🎉</h2>
             <span className={styles.paragraph}>
-                Double click to edit App component <br /> and drag here elements from Add Elements
-                Panel
+                Double click to edit App component <br /> and drag here elements from the Add
+                Elements Panel
             </span>
         </div>
     );

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -1,6 +1,6 @@
 :root {
     --my-prettyfont: 'DM Sans', sans-serif;
-    --large-font: 700 6rem/1.2 var(--my-prettyfont);
-    --small-font: 200 3rem/1.4 var(--my-prettyfont);
-    --paragraph-font: 200 2rem/1.3 var(--my-prettyfont);
+    --large-font: 700 8vw/1.2 var(--my-prettyfont);
+    --small-font: 200 5vw/1.4 var(--my-prettyfont);
+    --paragraph-font: 200 3vw/1.3 var(--my-prettyfont);
 }


### PR DESCRIPTION
to make the app preview look good, and the texts resize according to screen size, changed the texts to be defined as vw 


https://github.com/user-attachments/assets/476330c0-37e4-4e72-bb12-5ba8804c02d2

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/353d0b37-a6fc-4477-b5b5-6351bc4ea072">
