### PR TITLE
fix: component template redundant import

### DIFF
--- a/_codux/component-templates/default/new-component.module.scss
+++ b/_codux/component-templates/default/new-component.module.scss
@@ -1,4 +1,2 @@
-@import '../../../src/styles/theme.module.scss';
-
 .root {
 }


### PR DESCRIPTION
When we changed the common styles files structure we didn't remove a redundant import.