### PR TITLE
fix(home-page): remove unnecessary flex that makes weird behavior

### DIFF
--- a/app/routes/_index/_index.module.scss
+++ b/app/routes/_index/_index.module.scss
@@ -20,7 +20,6 @@
 .paragraph {
     font-size: 12px;
     margin-top: 80px;
-    display: flex;
     gap: 3px;
     justify-content: center;
     font: var(--paragraph-font);


### PR DESCRIPTION
When you edit text, it will make the texts to jump side-to-side.
This is a quick fix, but the actual issue is opened in Codux and known.
Still, unnecessary flex either way.