### PR TITLE
fix: update boards templates to work as expected

### DIFF
--- a/_codux/board-wrappers/component-wrapper/new-board.board.tsx
+++ b/_codux/board-wrappers/component-wrapper/new-board.board.tsx
@@ -1,18 +1,28 @@
 import { PropsWithChildren } from 'react';
 import { createRemixStub } from '@remix-run/testing';
 import { ROUTES } from '~/router/config';
+import { ContentSlot, createBoard } from '@wixc3/react-board';
 
 export interface ComponentWrapperProps extends PropsWithChildren {
     loaderData?: Record<string, unknown>;
 }
 
-export default function ComponentWrapper({ children, loaderData }: ComponentWrapperProps) {
+export function ComponentWrapper({ children, loaderData }: ComponentWrapperProps) {
     const RemixStub = createRemixStub([
         {
             Component: () => children,
-            children: [...Object.values(ROUTES).map(({ path }) => ({ path }))],
+            children: Object.values(ROUTES).map(({ path }) => ({ path }))
         },
     ]);
 
     return <RemixStub hydrationData={{ loaderData }} />;
 }
+
+export default createBoard({
+    name: 'NewBoard',
+    Board: () => (
+        <ComponentWrapper>
+            <ContentSlot />
+        </ComponentWrapper>
+    ),
+});

--- a/codux.config.json
+++ b/codux.config.json
@@ -10,6 +10,9 @@
     "componentsPath": "src/components",
     "templatesPath": "_codux/component-templates"
   },
+  "newBoard": {
+    "templatesPath": "_codux/board-wrappers"
+  },
   "safeRender": {
     "maxInstancesPerComponent": 1000
   },


### PR DESCRIPTION
Refactored and updated the board template, specifically the `component-wrapper`, to ensure it properly wraps the rendered component. This resolves issues where clicking on links could cause the board to break. These changes align with future plans to support navigation links and additional content, fostering more robust and predictable behavior.